### PR TITLE
Add Capgo for Capacitor live / OTA updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 #### Tools-Plugins
 
 - [Cordova / Phonegap iBeacon plugin](https://github.com/petermetz/cordova-plugin-ibeacon)
+- [Capgo](https://capgo.app/) - Live / OTA updates for Capacitor hybrid apps
 
 ## Miscellaneous
 


### PR DESCRIPTION
Adds Capgo under Hybrid Mobile → Tools-Plugins.

One line at the end of that section: live / OTA updates for Capacitor hybrid apps. Existing entries are unchanged.

Happy to drop the short description if you prefer name + URL only.